### PR TITLE
Add optimization option

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,11 @@ jobs:
           command: |
             poetry run make -C ultraface check
       - run:
+          name: check ultraface (no optimization)
+          working_directory: examples
+          command: |
+            poetry run make -C ultraface check-no-opt
+      - run:
           name: check ssd
           working_directory: examples
           command: |

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Use [Netron](https://netron.app).
 
 - Why is the extracted subgraph different from the original subgraph?
 
-onnigiri apply [onnx-simplifier](https://github.com/daquexian/onnx-simplifier) before extraction.
+onnigiri apply [onnx-simplifier](https://github.com/daquexian/onnx-simplifier) before extraction. You can disable the graph optimization by the onnx-simplifier using the `--no-optimization` option.
 
 ## Development Guide
 

--- a/examples/check_model.py
+++ b/examples/check_model.py
@@ -29,7 +29,7 @@ if __name__ == "__main__":
         shape = list()
         for d in i.type.tensor_type.shape.dim:
             shape.append(d.dim_value)
-        dtype = onnx.mapping.TENSOR_TYPE_TO_NP_TYPE[i.type.tensor_type.elem_type]
+        dtype = onnx.helper.tensor_dtype_to_np_dtype(i.type.tensor_type.elem_type)
         if len(shape) != 0:
             v = np.random.randn(*shape).astype(dtype)
             inputs[i.name] = v

--- a/examples/ultraface/Makefile
+++ b/examples/ultraface/Makefile
@@ -1,4 +1,4 @@
-.PHONY: check clean
+.PHONY: check check-no-opt clean
 
 ultraface.onnx:
 	wget -O $@ 'https://github.com/onnx/models/raw/main/vision/body_analysis/ultraface/models/version-RFB-640.onnx'
@@ -9,7 +9,16 @@ ultraface-main.onnx: ultraface.onnx
 ultraface-post.onnx: ultraface.onnx
 	onnigiri $^ -o $@ --from 314 --to boxes scores
 
+ultraface-main-no-opt.onnx: ultraface.onnx
+	onnigiri $^ -o $@ --from input --to 314
+
+ultraface-post-no-opt.onnx: ultraface.onnx
+	onnigiri $^ -o $@ --from 314 --to boxes scores
+
 check: ultraface.onnx ultraface-main.onnx ultraface-post.onnx
+	python ../check_model.py ultraface $^
+
+check-no-opt: ultraface.onnx ultraface-main-no-opt.onnx ultraface-post-no-opt.onnx
 	python ../check_model.py ultraface $^
 
 clean:

--- a/examples/ultraface/Makefile
+++ b/examples/ultraface/Makefile
@@ -10,10 +10,10 @@ ultraface-post.onnx: ultraface.onnx
 	onnigiri $^ -o $@ --from 314 --to boxes scores
 
 ultraface-main-no-opt.onnx: ultraface.onnx
-	onnigiri $^ -o $@ --from input --to 314
+	onnigiri $^ -o $@ --from input --to 314 --no-optimization
 
 ultraface-post-no-opt.onnx: ultraface.onnx
-	onnigiri $^ -o $@ --from 314 --to boxes scores
+	onnigiri $^ -o $@ --from 314 --to boxes scores --no-optimization
 
 check: ultraface.onnx ultraface-main.onnx ultraface-post.onnx
 	python ../check_model.py ultraface $^

--- a/flake.nix
+++ b/flake.nix
@@ -69,9 +69,9 @@
 
           inputsFrom = builtins.attrValues self.packages.${system};
 
-          shellHook = ''
-            export LD_LIBRARY_PATH=${pkgs.lib.makeLibraryPath [ pkgs.stdenv.cc.cc ]}
-          '';
+          # shellHook = ''
+          #   export LD_LIBRARY_PATH=${pkgs.lib.makeLibraryPath [ pkgs.stdenv.cc.cc ]}
+          # '';
         };
       }
     );

--- a/onnigiri/main.py
+++ b/onnigiri/main.py
@@ -124,7 +124,7 @@ def main() -> None:
         action=argparse.BooleanOptionalAction,
         dest="optimization",
         required=False,
-        help="perform optimization (default: True)",
+        help="perform optimization",
         default=True,
     )
     parser.add_argument("--from", nargs="+", dest="input_names", help="Names of input value")

--- a/onnigiri/main.py
+++ b/onnigiri/main.py
@@ -82,7 +82,12 @@ def validate_value_names(input_names: List[str], output_names: List[str], model:
 
 
 def onnigiri(
-    input_path: str, output_path: str, input_names: List[str], output_names: List[str], shapes: Dict[str, List[int]], optimization: bool
+    input_path: str,
+    output_path: str,
+    input_names: List[str],
+    output_names: List[str],
+    shapes: Dict[str, List[int]],
+    optimization: bool,
 ) -> None:
     model = onnx.load(input_path)
     if len(shapes) != 0:
@@ -114,12 +119,21 @@ def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("input_path", help="Input ONNX path")
     parser.add_argument("-o", "--output", dest="output_path", required=True, help="Output ONNX path")
-    parser.add_argument("--optimization", action=argparse.BooleanOptionalAction, dest="optimization", required=False, help="perform optimization (default: True)", default=True)
+    parser.add_argument(
+        "--optimization",
+        action=argparse.BooleanOptionalAction,
+        dest="optimization",
+        required=False,
+        help="perform optimization (default: True)",
+        default=True,
+    )
     parser.add_argument("--from", nargs="+", dest="input_names", help="Names of input value")
     parser.add_argument("--to", nargs="+", dest="output_names", help="Names of output value")
     parser.add_argument("--fix-input-shape", nargs="+", dest="shapes", default=[], help="Pairs of the name and shape of inputs")
     args = parser.parse_args()
-    onnigiri(args.input_path, args.output_path, args.input_names, args.output_names, parse_shapes(args.shapes), args.optimization)
+    onnigiri(
+        args.input_path, args.output_path, args.input_names, args.output_names, parse_shapes(args.shapes), args.optimization
+    )
 
 
 if __name__ == "__main__":

--- a/onnigiri/main.py
+++ b/onnigiri/main.py
@@ -82,14 +82,14 @@ def validate_value_names(input_names: List[str], output_names: List[str], model:
 
 
 def onnigiri(
-    input_path: str, output_path: str, input_names: List[str], output_names: List[str], shapes: Dict[str, List[int]]
+    input_path: str, output_path: str, input_names: List[str], output_names: List[str], shapes: Dict[str, List[int]], optimization: bool
 ) -> None:
     model = onnx.load(input_path)
     if len(shapes) != 0:
         fix_input_shapes(shapes, model)
     check_inputs(model.graph.input)
 
-    simplified_model, check = simplify(model)
+    simplified_model, check = simplify(model, perform_optimization=optimization)
     assert check, "Error: Simplified ONNX model could not be validated"
 
     fix_subgraphs(simplified_model.graph)
@@ -114,11 +114,12 @@ def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("input_path", help="Input ONNX path")
     parser.add_argument("-o", "--output", dest="output_path", required=True, help="Output ONNX path")
+    parser.add_argument("--optimization", action=argparse.BooleanOptionalAction, dest="optimization", required=False, help="perform optimization (default: True)", default=True)
     parser.add_argument("--from", nargs="+", dest="input_names", help="Names of input value")
     parser.add_argument("--to", nargs="+", dest="output_names", help="Names of output value")
     parser.add_argument("--fix-input-shape", nargs="+", dest="shapes", default=[], help="Pairs of the name and shape of inputs")
     args = parser.parse_args()
-    onnigiri(args.input_path, args.output_path, args.input_names, args.output_names, parse_shapes(args.shapes))
+    onnigiri(args.input_path, args.output_path, args.input_names, args.output_names, parse_shapes(args.shapes), args.optimization)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
グラフの最適化の有無をオプションで指定できるようにした。

```
% ./result/bin/onnigiri --help
usage: onnigiri [-h] -o OUTPUT_PATH [--optimization | --no-optimization] [--from INPUT_NAMES [INPUT_NAMES ...]] [--to OUTPUT_NAMES [OUTPUT_NAMES ...]] [--fix-input-shape SHAPES [SHAPES ...]] input_path

positional arguments:
  input_path            Input ONNX path

optional arguments:
  -h, --help            show this help message and exit
  -o OUTPUT_PATH, --output OUTPUT_PATH
                        Output ONNX path
  --optimization, --no-optimization
                        perform optimization (default: True)
  --from INPUT_NAMES [INPUT_NAMES ...]
                        Names of input value
  --to OUTPUT_NAMES [OUTPUT_NAMES ...]
                        Names of output value
  --fix-input-shape SHAPES [SHAPES ...]
                        Pairs of the name and shape of inputs
```